### PR TITLE
fix(event-handler): change module type to commonJS

### DIFF
--- a/event-handler/tsconfig.json
+++ b/event-handler/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
-    "module": "NodeNext",
+    "module": "CommonJS",
     "allowJs": false,
     "resolveJsonModule": true,
     "moduleDetection": "force",


### PR DESCRIPTION
It fixes the dynamic import which failed the test case after updating to ts-jest latest version
The root cause : https://github.com/microsoft/TypeScript/issues/59257
reference : https://github.com/kulshekhar/ts-jest/issues/4751#issuecomment-2758667892