### PR TITLE
fix(processor): fix purchase country

### DIFF
--- a/processor/src/services/helpers/transformCommercetoolsToIngridDTOs.ts
+++ b/processor/src/services/helpers/transformCommercetoolsToIngridDTOs.ts
@@ -30,7 +30,7 @@ export const transformCommercetoolsCartToIngridPayload = (ctCart: Cart): IngridC
   const payload: IngridCreateSessionRequestPayload = {
     cart: transformedCart,
     locales: [ctCart.locale!],
-    purchase_country: ctCart.country!,
+    purchase_country: ctCart.shippingAddress?.country ?? ctCart.country!,
     purchase_currency: ctCart.totalPrice.currencyCode,
   };
 


### PR DESCRIPTION
- When cart country is different from shipping country, it assigns shipping country into ingrid purchase country to avoid binding shipping address to cart country.