### PR TITLE
fix(processor): exclude shipping cost from Ingrid cart total amount

### DIFF
--- a/processor/src/services/helpers/transformCommercetoolsToIngridDTOs.ts
+++ b/processor/src/services/helpers/transformCommercetoolsToIngridDTOs.ts
@@ -26,7 +26,6 @@ export const transformCommercetoolsCartToIngridPayload = (ctCart: Cart): IngridC
   }
 
   const transformedCart = transformCommercetoolsCartToIngridCart(ctCart);
-
   const payload: IngridCreateSessionRequestPayload = {
     cart: transformedCart,
     locales: [ctCart.locale!],
@@ -71,13 +70,18 @@ const transformCommercetoolsCartToIngridCart = (ctCart: Cart): IngridCart => {
   const totalDiscount = (ctCart.discountOnTotalPrice?.discountedAmount.centAmount ?? 0) + totalLineItemsDiscount;
 
   const lineItems = transformCommercetoolsLineItemsToIngridCartItems(ctCart.lineItems, ctCart.locale!);
-
   return {
-    total_value: ctCart.taxedPrice?.totalGross.centAmount ?? ctCart.totalPrice.centAmount, // use "taxedPrice.totalGross" because Ingrid accepts tax inclusive price.
+    total_value: deductShippingCostFromCartTotalPrice(ctCart),
     total_discount: totalDiscount,
     items: lineItems,
     cart_id: ctCart.id,
   };
+};
+
+const deductShippingCostFromCartTotalPrice = (ctCart: Cart): number => {
+  const shippingCost = ctCart.shippingInfo?.price.centAmount ?? 0;
+  const totalCartPrice = ctCart.taxedPrice?.totalGross.centAmount ?? ctCart.totalPrice.centAmount; // use "taxedPrice.totalGross" because Ingrid accepts tax inclusive price.
+  return totalCartPrice - shippingCost;
 };
 
 /**


### PR DESCRIPTION
- Ingrid accepts the cart with total price excluding the shipping cost.
- Since commercetools cart total price always include a shipping cost whenever shipping info exists, a deduction logic needs to be applied additionally to exclude the shipping cost from the Ingrid cart