### PR TITLE
fix(event-handler): put order number as Ingrid external ID

### DIFF
--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "enabler",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "enabler",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dependencies": {
         "serve": "14.2.4"
       },

--- a/enabler/package.json
+++ b/enabler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enabler",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",

--- a/enabler/src/configurator/stores/cocoSessionStore.ts
+++ b/enabler/src/configurator/stores/cocoSessionStore.ts
@@ -2,6 +2,15 @@ import cartStore from "./cartStore";
 import loadingStore from "./loadingStore";
 import Store from "./Store";
 
+const generateOrderNumber = () => {
+  const date = new Date();
+  const year = date.getFullYear().toString().slice(-2);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const randomPart = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
+  return `${year}${month}${day}-${randomPart}`; // e.g. "231001-1234"
+}
+
 function createToken() {
   return fetch(`${import.meta.env.VITE_CTP_AUTH_URL}/oauth/token`, {
     method: "POST",
@@ -38,6 +47,7 @@ async function createSession(cartId: string) {
         },
         metadata: {
           applicationKey: import.meta.env.VITE_CTP_APPLICATION_KEY ?? "",
+          futureOrderNumber: generateOrderNumber(),
         }
       }),
     }
@@ -114,6 +124,8 @@ cartStore.subscribe(() => {
         .finally(() => loadingStore.dispatch("DONE"));
     }
   }
-});
+  
 
+});
+  
 export default cocoSessionStore;

--- a/event-handler/package-lock.json
+++ b/event-handler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shipping-integration-ingrid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shipping-integration-ingrid",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@commercetools-backend/loggers": "^24.2.1",

--- a/event-handler/package.json
+++ b/event-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipping-integration-ingrid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "main": "index.js",
   "license": "MIT",
   "private": true,

--- a/event-handler/src/app.ts
+++ b/event-handler/src/app.ts
@@ -24,10 +24,9 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 // Define routes
 app.use('/', EventRoutes);
-app.use('*splat', () => {
-  throw new CustomError(404, 'Path not found.');
+app.use('*splat', (_req, _res, next) => {
+  next(new CustomError(404, 'Path not found.'));
 });
-
 // Global error handler
 app.use(errorMiddleware);
 

--- a/event-handler/src/client/ingrid/ingrid.client.ts
+++ b/event-handler/src/client/ingrid/ingrid.client.ts
@@ -26,10 +26,10 @@ export default class IngridApiClient {
         payload
       );
       return response.data as IngridCompleteSessionResponse;
-    } catch (error: Error | any) {
+    } catch (error: unknown) {
       throw new CustomError(
         202,
-        `Failed to complete session on Ingrid. ${error.message} `,
+        `Failed to complete session on Ingrid. ${error instanceof Error ? error.message : String(error)}`,
         {
           cause: error instanceof Error ? error : new Error(String(error)),
         }

--- a/event-handler/src/client/ingrid/ingrid.client.ts
+++ b/event-handler/src/client/ingrid/ingrid.client.ts
@@ -26,10 +26,14 @@ export default class IngridApiClient {
         payload
       );
       return response.data as IngridCompleteSessionResponse;
-    } catch (error) {
-      throw new CustomError(400, 'Failed to complete session on Ingrid.', {
-        cause: error instanceof Error ? error : new Error(String(error)),
-      });
+    } catch (error: Error | any) {
+      throw new CustomError(
+        202,
+        `Failed to complete session on Ingrid. ${error.message} `,
+        {
+          cause: error instanceof Error ? error : new Error(String(error)),
+        }
+      );
     }
   }
 }

--- a/event-handler/src/controllers/event.controller.ts
+++ b/event-handler/src/controllers/event.controller.ts
@@ -113,8 +113,7 @@ export const post = async (request: Request, response: Response) => {
   if (responseObj.status === 'COMPLETE') {
     const updateOrderResult = await changeShipmentState(
       orderId,
-      // updatedCommercetoolsOrder ? updatedCommercetoolsOrder.version : commercetoolsOrder.version,
-      commercetoolsOrder.version,
+      updatedCommercetoolsOrder ? updatedCommercetoolsOrder.version : commercetoolsOrder.version,
       SHIPMENT_STATE.READY
     );
     logger.info(

--- a/event-handler/src/controllers/event.controller.ts
+++ b/event-handler/src/controllers/event.controller.ts
@@ -113,7 +113,9 @@ export const post = async (request: Request, response: Response) => {
   if (responseObj.status === 'COMPLETE') {
     const updateOrderResult = await changeShipmentState(
       orderId,
-      updatedCommercetoolsOrder ? updatedCommercetoolsOrder.version : commercetoolsOrder.version,
+      updatedCommercetoolsOrder
+        ? updatedCommercetoolsOrder.version
+        : commercetoolsOrder.version,
       SHIPMENT_STATE.READY
     );
     logger.info(

--- a/event-handler/src/middleware/error.middleware.ts
+++ b/event-handler/src/middleware/error.middleware.ts
@@ -4,8 +4,9 @@ import { logger } from '../utils/logger.utils';
 
 export const errorMiddleware: ErrorRequestHandler = (
   error: Error,
-  _: Request,
+  _req: Request,
   res: Response,
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   _next: (err?: Error) => void
 ) => {
   const isDevelopment = process.env.NODE_ENV === 'development';

--- a/event-handler/test/controllers/event.controller.spec.ts
+++ b/event-handler/test/controllers/event.controller.spec.ts
@@ -80,7 +80,7 @@ describe('Event Controller', () => {
       mockOrderId
     );
 
-    const mockCommercetoolsGetOrders = mockApiRootOrderResponse({
+    const mockOrder = {
       body: {
         cart: {
           obj: {
@@ -91,8 +91,11 @@ describe('Event Controller', () => {
             },
           },
         },
+        orderNumber: 'test-order-number',
       },
-    });
+    };
+
+    const mockCommercetoolsGetOrders = mockApiRootOrderResponse(mockOrder);
     (createApiRoot as MockFn).mockReturnValue({
       orders: mockCommercetoolsGetOrders,
     });
@@ -146,7 +149,7 @@ describe('Event Controller', () => {
       IngridApiClient.prototype.completeCheckoutSession
     ).toHaveBeenCalledWith({
       checkout_session_id: mockIngridSessionId,
-      external_id: mockOrderId,
+      external_id: mockOrder?.body?.orderNumber,
     });
 
     expect(logger.info).toHaveBeenCalledWith(
@@ -165,7 +168,7 @@ describe('Event Controller', () => {
       orderId: mockOrderId,
     });
 
-    const mockCommercetoolsGetOrders = mockApiRootOrderResponse({
+    const mockOrder = {
       body: {
         cart: {
           obj: {
@@ -174,8 +177,11 @@ describe('Event Controller', () => {
             },
           },
         },
+        id: 'test-order-id',
+        orderNumber: 'test-order-number',
       },
-    });
+    };
+    const mockCommercetoolsGetOrders = mockApiRootOrderResponse(mockOrder);
 
     (createApiRoot as MockFn).mockReturnValue({
       orders: mockCommercetoolsGetOrders,
@@ -187,7 +193,9 @@ describe('Event Controller', () => {
 
     await expect(
       post(mockRequest as Request, mockResponse as Response)
-    ).rejects.toThrow('Bad request. Ingrid session ID not found');
+    ).rejects.toThrow(
+      `Ingrid session ID not found for the order with ID ${mockOrder.body.id}.`
+    );
   });
 
   it('should throw error when PubSub validation fails', async () => {
@@ -232,6 +240,7 @@ describe('Event Controller', () => {
             },
           },
         },
+        orderNumber: 'test-order-number',
       },
     });
 
@@ -300,6 +309,7 @@ describe('Event Controller', () => {
             },
           },
         },
+        orderNumber: 'test-order-number',
       },
     });
 
@@ -383,7 +393,7 @@ describe('Event Controller', () => {
 
     // Mock createApiRoot get order response with missing ingridSessionId
     // Mock createApiRoot get order response
-    const mockCommercetoolsGetOrders = mockApiRootOrderResponse({
+    const mockOrder = {
       body: {
         id: mockOrderId,
         version: mockVersion,
@@ -396,8 +406,11 @@ describe('Event Controller', () => {
             },
           },
         },
+
+        orderNumber: 'test-order-number',
       },
-    });
+    };
+    const mockCommercetoolsGetOrders = mockApiRootOrderResponse(mockOrder);
 
     (createApiRoot as MockFn).mockReturnValue({
       orders: mockCommercetoolsGetOrders,
@@ -406,7 +419,9 @@ describe('Event Controller', () => {
     // Execute test
     await expect(
       post(mockRequest as Request, mockResponse as Response)
-    ).rejects.toThrow('Bad request. Ingrid session ID not found');
+    ).rejects.toThrow(
+      `Ingrid session ID not found for the order with ID ${mockOrder.body.id}.`
+    );
   });
 
   // Test for handling RESOURCE_CREATED_MESSAGE

--- a/event-handler/test/middleware/error.middleware.spec.ts
+++ b/event-handler/test/middleware/error.middleware.spec.ts
@@ -127,7 +127,7 @@ describe('Error Middleware', () => {
       error.message,
       error
     );
-    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.status).toHaveBeenCalledWith(202);
     expect(mockResponse.send).toHaveBeenCalledWith({
       message: 'Something went wrong',
     });
@@ -150,7 +150,7 @@ describe('Error Middleware', () => {
       error.message,
       error
     );
-    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.status).toHaveBeenCalledWith(202);
     expect(mockResponse.send).toHaveBeenCalledWith({
       message: 'Internal server error',
     });

--- a/event-handler/test/mock/mock-api-root.ts
+++ b/event-handler/test/mock/mock-api-root.ts
@@ -17,6 +17,7 @@ interface MockGetOrderResponse {
         };
       };
     };
+    orderNumber?: string;
   };
 }
 

--- a/event-handler/test/routes/event.route.spec.ts
+++ b/event-handler/test/routes/event.route.spec.ts
@@ -107,7 +107,7 @@ describe('Error handling', () => {
   test('should handle unexpected errors with 500 status', async () => {
     const response = await request(mockApp).post('/').send({ test: 'data' });
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(202);
     // In production mode, expect { message: 'Internal server error' }
     // But we're not checking body due to test environment inconsistencies
   });

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shipping-integration-ingrid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shipping-integration-ingrid",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
         "@commercetools-backend/loggers": "24.2.1",

--- a/processor/package.json
+++ b/processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipping-integration-ingrid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "shipping integration ingrid connector",
   "main": "dist/server.js",
   "scripts": {


### PR DESCRIPTION
- Put commercetools order number as Ingrid external ID since it is user-maintained identifier.
- Return 202 HTTP status instead of 400 and 500 to avoid GCP pub/sub retry which causes message flooding.
- Fix error middleware which cannot be executed all the time
- Fix ConcurrentModificationException during updating the `orderShipmentState` after updating TOS ID into order.
- Update unit test cases