### PR TITLE
Fix: handle large requests

### DIFF
--- a/event-handler/src/app.ts
+++ b/event-handler/src/app.ts
@@ -19,8 +19,8 @@ const app: Express = express();
 app.disable('x-powered-by');
 
 // Define configurations
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '10mb' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }));
 
 // Define routes
 app.use('/', EventRoutes);


### PR DESCRIPTION
Default value for request size of [100kb](https://expressjs.com/en/resources/middleware/body-parser.html#limit) is insufficient. 